### PR TITLE
Image caching improvements

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -22,6 +22,7 @@ interface ImageProps {
   preview?: ImageSourcePropType;
   options?: DownloadOptions;
   uri: string;
+  cacheKey?: string;
   transitionDuration?: number;
   tint?: "dark" | "light";
 }
@@ -66,9 +67,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
     this.mounted = false;
   }
 
-  async load({ uri, options = {} }: ImageProps): Promise<void> {
+  async load({ uri, options = {}, cacheKey }: ImageProps): Promise<void> {
     if (uri) {
-      const path = await CacheManager.get(uri, options).getPath();
+      const path = await CacheManager.get(uri, options, cacheKey || uri).getPath();
       if (this.mounted) {
         this.setState({ uri: path });
       }


### PR DESCRIPTION
    Add an optional cache key

    Add an option to use a cache key that is different from the image
    URI. This is useful for example if the image URI contains a parameter
    that changes, but the image doesn't vary as a result, such as an
    authentication token.

    If the cache key is not present, the image URI will be used as the
    cache key.

And

    Avoid repeat downloads

    Create a single promise to handle the downloading of a cache
    entry. Otherwise, multiple calls to get the path of a new cache
    entry will result in multiple downloads, until one of the downloads
    is successful.

    If the download is unsuccesful, unset the promise so that the
    next request will result in a new attempt to download the image.

